### PR TITLE
Update node versions

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        node_version: [16, 18, 19, 20]
+        node_version: [16, 18, 20]
         include:
           - os: macos-latest
             node_version: 18

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version-file: '.nvmrc'
           registry-url: 'https://registry.npmjs.org'
       - name: install
         run: yarn install --immutable

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/gallium
+lts/hydrogen


### PR DESCRIPTION
# What's changed

- drop node 19 from ci
- use node 18 for development
- use .nvmrc for the release build